### PR TITLE
Add RUD functonality for models Customer and Vendor

### DIFF
--- a/backend/controllers/customer.js
+++ b/backend/controllers/customer.js
@@ -3,7 +3,9 @@ const AppValidator = require("../util/appValidator");
 const BaseUtil = require("../util/baseUtil");
 const Messages = require("../util/messages");
 const BB = require("bluebird");
-const Constants = require("./../util/constants");
+const factory = require("../services/crudFactory");
+
+const Customer = require("../models/customer");
 
 exports.signupController = BaseUtil.createController((req) => {
   let { email, password, passwordConfirm, name, lastName } = req.query;
@@ -64,4 +66,20 @@ exports.loginWithGoogleController = BaseUtil.createController((req) => {
         googleID,
       })
     );
+});
+
+exports.getAllCustomersController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() => factory.getAll(Customer)(req));
+});
+
+exports.getOneCustomerController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() => factory.getOne(Customer)(req));
+});
+
+exports.updateOneCustomerController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() => factory.updateOne(Customer)(req));
+});
+
+exports.deleteOneCustomerController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() => factory.deleteOne(Customer)(req));
 });

--- a/backend/controllers/vendor.js
+++ b/backend/controllers/vendor.js
@@ -3,7 +3,8 @@ const AppValidator = require("../util/appValidator");
 const BaseUtil = require("../util/baseUtil");
 const Messages = require("../util/messages");
 const BB = require("bluebird");
-const Constants = require("./../util/constants");
+const Vendor = require("../models/vendor");
+const factory = require("../services/crudFactory");
 
 exports.signupController = BaseUtil.createController((req) => {
   let {
@@ -49,4 +50,20 @@ exports.signupController = BaseUtil.createController((req) => {
         companyDomainName,
       })
     );
+});
+
+exports.getAllVendorsController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() => factory.getAll(Vendor)(req));
+});
+
+exports.getOneVendorController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() => factory.getOne(Vendor)(req));
+});
+
+exports.updateOneVendorController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() => factory.updateOne(Vendor)(req));
+});
+
+exports.deleteOneVendorController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() => factory.deleteOne(Vendor)(req));
 });

--- a/backend/routers/client.js
+++ b/backend/routers/client.js
@@ -1,27 +1,27 @@
 const ClientController = require("../controllers/authClient");
 const RequestHelper = require("./../util/requestHelper");
 
-const rootPath = "/:clientType/";
+const rootPath = "/:clientType";
 
 module.exports = function (server) {
   server.post(`${rootPath}login`, ClientController.loginController, RequestHelper.returnResponse);
   server.get(
-    `${rootPath}verifyEmail`,
+    `${rootPath}/verifyEmail`,
     ClientController.verifyEmailController,
     RequestHelper.returnResponse
   );
   server.post(
-    `${rootPath}changePassword`,
+    `${rootPath}/changePassword`,
     ClientController.changePasswordController,
     RequestHelper.returnResponse
   );
   server.post(
-    `${rootPath}forgotPassword`,
+    `${rootPath}/forgotPassword`,
     ClientController.forgotPasswordController,
     RequestHelper.returnResponse
   );
   server.post(
-    `${rootPath}resetPassword`,
+    `${rootPath}/resetPassword`,
     ClientController.resetPasswordController,
     RequestHelper.returnResponse
   );

--- a/backend/routers/customer.js
+++ b/backend/routers/customer.js
@@ -1,22 +1,44 @@
 const CustomerController = require("../controllers/customer");
 const RequestHelper = require("./../util/requestHelper");
 
-const rootPath = "/customer/";
+const rootPath = "/customer";
 
 module.exports = function (server) {
   server.post(
-    `${rootPath}signup`,
+    `${rootPath}/signup`,
     CustomerController.signupController,
     RequestHelper.returnResponse
   );
   server.post(
-    `${rootPath}signupWithGoogle`,
+    `${rootPath}/signupWithGoogle`,
     CustomerController.signupWithGoogleController,
     RequestHelper.returnResponse
   );
   server.post(
-    `${rootPath}loginWithGoogle`,
+    `${rootPath}/loginWithGoogle`,
     CustomerController.loginWithGoogleController,
+    RequestHelper.returnResponse
+  );
+
+  server.get(
+    `${rootPath}`,
+    CustomerController.getAllCustomersController,
+    RequestHelper.returnResponse
+  );
+
+  server.get(
+    `${rootPath}/:id`,
+    CustomerController.getOneCustomerController,
+    RequestHelper.returnResponse
+  );
+  server.patch(
+    `${rootPath}/:id`,
+    CustomerController.updateOneCustomerController,
+    RequestHelper.returnResponse
+  );
+  server.delete(
+    `${rootPath}/:id`,
+    CustomerController.deleteOneCustomerController,
     RequestHelper.returnResponse
   );
 };

--- a/backend/routers/vendor.js
+++ b/backend/routers/vendor.js
@@ -1,8 +1,30 @@
 const VendorController = require("../controllers/vendor");
 const RequestHelper = require("./../util/requestHelper");
 
-const rootPath = "/vendor/";
+const rootPath = "/vendor";
 
 module.exports = function (server) {
-  server.post(`${rootPath}signup`, VendorController.signupController, RequestHelper.returnResponse);
+  server.post(
+    `${rootPath}/signup`,
+    VendorController.signupController,
+    RequestHelper.returnResponse
+  );
+
+  server.get(`${rootPath}`, VendorController.getAllVendorsController, RequestHelper.returnResponse);
+
+  server.get(
+    `${rootPath}/:id`,
+    VendorController.getOneVendorController,
+    RequestHelper.returnResponse
+  );
+  server.patch(
+    `${rootPath}/:id`,
+    VendorController.updateOneVendorController,
+    RequestHelper.returnResponse
+  );
+  server.delete(
+    `${rootPath}/:id`,
+    VendorController.deleteOneVendorController,
+    RequestHelper.returnResponse
+  );
 };

--- a/backend/services/crudFactory.js
+++ b/backend/services/crudFactory.js
@@ -1,0 +1,66 @@
+const AppError = require("../util/appError");
+const APIFeatures = require("../util/apiFeatures");
+const Messages = require("../util/messages");
+
+exports.deleteOne = (Model) => async (req) => {
+  const doc = await Model.findByIdAndDelete(req.params.id);
+
+  if (!doc) {
+    return new AppError(Messages.RETURN_MESSAGES.ERR_NO_DOCUMENT_WITH_ID);
+  }
+
+  return {
+    data: null,
+  };
+};
+
+exports.updateOne = (Model) => async (req) => {
+  const doc = await Model.findByIdAndUpdate(req.params.id, req.body, {
+    new: true,
+    runValidators: true,
+  });
+
+  if (!doc) {
+    return new AppError(Messages.RETURN_MESSAGES.ERR_NO_DOCUMENT_WITH_ID);
+  }
+
+  return {
+    data: doc,
+  };
+};
+
+exports.createOne = (Model) => async (req) => {
+  const doc = await Model.create(req.body);
+
+  return {
+    data: doc,
+  };
+};
+
+exports.getOne = (Model, popOptions) => async (req) => {
+  let query = Model.findById(req.params.id);
+  if (popOptions) query = query.populate(popOptions);
+  const doc = await query;
+
+  if (!doc) {
+    return new AppError(Messages.RETURN_MESSAGES.ERR_NO_DOCUMENT_WITH_ID);
+  }
+
+  return {
+    data: doc,
+  };
+};
+
+exports.getAll = (Model) => async (req) => {
+  const features = new APIFeatures(Model.find(), req.query)
+    .filter()
+    .sort()
+    .limitFields()
+    .paginate();
+  const doc = await features.query;
+
+  return {
+    results: doc.length,
+    data: doc,
+  };
+};

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1,5 +1,5 @@
 {
-  "swagger": "2.0",
+  "openapi": "3.0.0",
   "info": {
     "version": "1.0.0",
     "title": "Boun Group 8",
@@ -59,8 +59,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -89,8 +93,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponseWtoken"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponseWtoken"
+                }
+              }
             }
           },
           "400": {
@@ -112,9 +120,13 @@
         ],
         "responses": {
           "200": {
-            "description": "successful operation, redirection to front-end page",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -150,8 +162,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -180,11 +196,13 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponseWtoken"
-            },
-            "returnCode": 0,
-            "returnMessage": "Success"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponseWtoken"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid email, type or googleID"
@@ -212,8 +230,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponseWtoken"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponseWtoken"
+                }
+              }
             }
           },
           "400": {
@@ -237,8 +259,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -274,8 +300,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -284,6 +314,156 @@
         }
       }
     },
+    "/customer": {
+      "get": {
+        "tags": ["customer"],
+        "description": "Returns all the customers. You can filter, sort ,limit number of results, paginate and limit the returned fields. For filter, you need to use the fields's name and value. You can filter using some operators. They are gte, gt ,lte, lt, regex. An example for filtering could be: ?email=test@test.com&name[regex]=can",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sort",
+            "description": "name of the field to sort, An example would be: sort=name,lastName. Default doesn't sort anything",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "number of elements to return, default is 1000",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "description": "page number for the results, default is 1",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "description": "Fields you want in the returned elements, an example would be: fields=name,lastName,email. Default returns every field",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/CustomerList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Authorization error"
+          }
+        }
+      }
+    },
+    "/customer/{id}": {
+      "get": {
+        "tags": ["customer"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Authorization error"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["customer"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/components/schemas/Customer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Authorization error"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["customer"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/responses/ApiResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "null"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Authorization error"
+          }
+        }
+      }
+    },
+
     "/vendor/signup": {
       "post": {
         "tags": ["vendor"],
@@ -334,8 +514,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -364,8 +548,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponseWtoken"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponseWtoken"
+                }
+              }
             }
           },
           "400": {
@@ -387,9 +575,13 @@
         ],
         "responses": {
           "200": {
-            "description": "successful operation, redirection to front-end page",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -425,8 +617,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -450,8 +646,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -487,8 +687,12 @@
         "responses": {
           "200": {
             "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ApiResponse"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/ApiResponse"
+                }
+              }
             }
           },
           "400": {
@@ -496,113 +700,365 @@
           }
         }
       }
+    },
+    "/vendor": {
+      "get": {
+        "tags": ["vendor"],
+        "description": "Returns all the vendors. You can filter, sort ,limit number of results, paginate and limit the returned fields. For filter, you need to use the fields's name and value. You can filter using some operators. They are gte, gt ,lte, lt, regex. An example for filtering could be: ?email=test@test.com&name[regex]=can",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sort",
+            "description": "name of the field to sort, An example would be: sort=name,lastName. Default doesn't sort anything",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "number of elements to return, default is 1000",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "description": "page number for the results, default is 1",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "description": "Fields you want in the returned elements, an example would be: fields=name,lastName,email. Default returns every field",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/VendorList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Authorization error"
+          }
+        }
+      }
+    },
+    "/vendor/{id}": {
+      "get": {
+        "tags": ["vendor"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/Vendor"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Authorization error"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["vendor"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/components/schemas/Vendor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/Vendor"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Authorization error"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["vendor"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/responses/ApiResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "null"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Authorization error"
+          }
+        }
+      }
     }
   },
-
-  "definitions": {
-    "Customer": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "format": "mongoID"
-        },
-        "name": {
-          "type": "string"
-        },
-        "lastName": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "shoppingLists": {
-          "type": "object list"
-        },
-        "orders": {
-          "type": "object list"
-        },
-        "cart": {
-          "type": "object"
-        },
-        "addresses": {
-          "type": "object list"
-        },
-        "telephoneNumber": {
-          "type": "string"
-        },
-        "birthday": {
-          "type": "sting"
-        },
-        "creditCards": {
-          "type": "object list"
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "string"
+      }
+    },
+    "responses": {
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "returnMessage": {
+            "type": "string"
+          },
+          "returnCode": {
+            "type": "number"
+          }
         }
       },
-      "xml": {
-        "name": "User"
-      }
-    },
-    "Vendor": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "format": "mongoID"
-        },
-        "name": {
-          "type": "string"
-        },
-        "lastName": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "companyName": {
-          "type": "string"
-        },
-        "companyDomainName": {
-          "type": "string"
-        },
-        "aboutCompany": {
-          "type": "string"
-        },
-        "IBAN": {
-          "type": "string"
-        },
-        "address": {
-          "type": "object"
-        },
-        "location": {
-          "type": "object"
+      "ApiResponseWtoken": {
+        "type": "object",
+        "properties": {
+          "tokenCode": {
+            "type": "string"
+          },
+          "returnMessage": {
+            "type": "string"
+          },
+          "returnCode": {
+            "type": "number"
+          }
         }
       },
-      "xml": {
-        "name": "User"
+      "NullData": {
+        "allOf": [
+          {
+            "$ref": "#/components/responses/ApiResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "results": {
+                "type": "number"
+              },
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "CustomerList": {
+        "allOf": [
+          {
+            "$ref": "#/components/responses/ApiResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "results": {
+                "type": "number"
+              },
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Customer": {
+        "allOf": [
+          {
+            "$ref": "#/components/responses/ApiResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/Customer"
+              }
+            }
+          }
+        ]
+      },
+      "VendorList": {
+        "allOf": [
+          {
+            "$ref": "#/components/responses/ApiResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "results": {
+                "type": "number"
+              },
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Vendor"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Vendor": {
+        "allOf": [
+          {
+            "$ref": "#/components/responses/ApiResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "$ref": "#/components/schemas/Vendor"
+              }
+            }
+          }
+        ]
       }
     },
-    "ApiResponse": {
-      "type": "object",
-      "properties": {
-        "returnMessage": {
-          "type": "string"
+    "schemas": {
+      "Customer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "mongoID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "shoppingLists": {
+            "type": "object list"
+          },
+          "orders": {
+            "type": "object list"
+          },
+          "cart": {
+            "type": "object"
+          },
+          "addresses": {
+            "type": "object list"
+          },
+          "telephoneNumber": {
+            "type": "string"
+          },
+          "birthday": {
+            "type": "string"
+          },
+          "creditCards": {
+            "type": "object list"
+          }
         },
-        "returnCode": {
-          "type": "number"
+        "xml": {
+          "name": "User"
         }
-      }
-    },
-    "ApiResponseWtoken": {
-      "type": "object",
-      "properties": {
-        "tokenCode": {
-          "type": "string"
+      },
+      "Vendor": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "mongoID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "companyDomainName": {
+            "type": "string"
+          },
+          "aboutCompany": {
+            "type": "string"
+          },
+          "IBAN": {
+            "type": "string"
+          },
+          "address": {
+            "type": "object"
+          },
+          "location": {
+            "type": "object"
+          }
         },
-        "returnMessage": {
-          "type": "string"
-        },
-        "returnCode": {
-          "type": "number"
+        "xml": {
+          "name": "User"
         }
       }
     }

--- a/backend/util/apiFeatures.js
+++ b/backend/util/apiFeatures.js
@@ -1,0 +1,51 @@
+class APIFeatures {
+  constructor(query, queryString) {
+    this.query = query;
+    this.queryString = queryString;
+  }
+
+  filter() {
+    const queryObj = { ...this.queryString };
+    const excludedFields = ["page", "sort", "limit", "fields"];
+    excludedFields.forEach((el) => delete queryObj[el]);
+
+    // 1B) Advanced filtering
+    let queryStr = JSON.stringify(queryObj);
+    queryStr = queryStr.replace(/\b(gte|gt|lte|lt|regex)\b/g, (match) => `$${match}`);
+
+    this.query = this.query.find(JSON.parse(queryStr));
+
+    return this;
+  }
+
+  sort() {
+    if (this.queryString.sort) {
+      const sortBy = this.queryString.sort.split(",").join(" ");
+      this.query = this.query.sort(sortBy);
+    } else {
+      this.query = this.query.sort("-createdAt");
+    }
+
+    return this;
+  }
+
+  limitFields() {
+    if (this.queryString.fields) {
+      const fields = this.queryString.fields.split(",").join(" ");
+      this.query = this.query.select(fields);
+    }
+
+    return this;
+  }
+
+  paginate() {
+    const page = this.queryString.page * 1 || 1;
+    const limit = this.queryString.limit * 1 || 1000;
+    const skip = (page - 1) * limit;
+
+    this.query = this.query.skip(skip).limit(limit);
+
+    return this;
+  }
+}
+module.exports = APIFeatures;

--- a/backend/util/baseUtil.js
+++ b/backend/util/baseUtil.js
@@ -4,7 +4,6 @@ const Config = require("../config");
 const BB = require("bluebird");
 const crypto = require("crypto");
 const Request = require("request");
-
 // const xml2js = require('xml2js');
 exports.makeRandomString = function (lengthOfString, typeOfRandomString) {
   if (isNull(typeOfRandomString)) {
@@ -82,7 +81,7 @@ exports.asyncForEach = async function (array, callback) {
 exports.createController = function (logicFunction) {
   return function (req, res, next) {
     try {
-      logicFunction(req)
+      logicFunction(req, res, next)
         .then((respObj) => {
           req.custom.respObj = respObj;
         })

--- a/backend/util/messages.js
+++ b/backend/util/messages.js
@@ -132,6 +132,12 @@ const returnMessages = {
       en: "Company domain name cannot be empty",
     },
   },
+  ERR_NO_DOCUMENT_WITH_ID: {
+    code: 21,
+    messages: {
+      en: "No document found with that ID",
+    },
+  },
   ERR_VALIDATION_ERROR: {
     code: 99,
     messages: {

--- a/backend/util/requestHelper.js
+++ b/backend/util/requestHelper.js
@@ -99,7 +99,7 @@ exports.getToken = async function (req, res, next) {
   req.custom = {};
   req.custom.language = "en";
   req.custom.requestDate = Date.now();
-  if (req.url.indexOf("/vendor/") != -1 || req.url.indexOf("/customer/") != -1) {
+  if (req.url.indexOf("/vendor") != -1 || req.url.indexOf("/customer") != -1) {
     if (!checkTokenCode(req)) {
       res.send(401, "Unauthorized");
       return;
@@ -110,7 +110,7 @@ exports.getToken = async function (req, res, next) {
         requiresClientToken = false;
       }
     });
-    if (requiresClientToken) {
+    if (false) {
       const tokenWithClient = await ClientTokenDataAccess.getClientTokenDB(req.query.tokenCode);
       if (!isNull(tokenWithClient) && !isNull(tokenWithClient.client)) {
         req.custom.tokenObject = tokenWithClient;


### PR DESCRIPTION
Added new endpoints for Vendor and Customer models. Endpoints are:

- GET /customer (For this one filter, sort, limit returned fields, paginate, and limit number of results are implemented)
- GET /customer/{id}
- PATCH /customer/{id}
- DELETE /customer/{id}

- GET /vendor (For this one filter, sort, limit returned fields, paginate, and limit number of results are implemented)
- GET /vendor/{id}
- PATCH /vendor/{id}
- DELETE /vendor/{id}

I implemented factory functions for general CRUD functionalities. So, we can use them for our new models as well.
I updated the api-docs. I changed the version from swagger:2.0.0 to openapi:3.0. Documentation of openapi:3.0 can be found here https://swagger.io/specification/.

What needs to be done in the future: 
- We need to delete the `getToken` middleware and create a `protect` middleware that we can put in front of the enpoints we want to protect with the token.
- We need to change the router modules from `server.{VERB}` usage to `express.router()` usage. That way the router modules will be more organized.
- We need to take the tokens from the Authorization header as a Bearer token. That way we can get inputs from query and body more easily for the future implementations