### PR TITLE
Move carousel and image resizer library from devDep to dependencies

### DIFF
--- a/web/carousel/package-lock.json
+++ b/web/carousel/package-lock.json
@@ -13914,7 +13914,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-alice-carousel/-/react-alice-carousel-2.1.0.tgz",
       "integrity": "sha512-AprO4ndVhi9aYYZ4LhTiDT/1oSMikITYG5HsHrU8FKlFN74Ph7xzi8Gm/d3QtoaWbZ2dg+B+RZw0u7z0DdQk/g==",
-      "dev": true,
       "requires": {
         "vanilla-swipe": "^2.2.0"
       }
@@ -14098,8 +14097,7 @@
     "react-image-resizer": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-image-resizer/-/react-image-resizer-1.3.0.tgz",
-      "integrity": "sha512-JZwNWumImYwPNeaf+MV5wEtUvyPK8crjLYo7AVf3/3LQ92oPwi/Clxmg76f14EQm73cbwxKgXTlJbFOSRGQGtA==",
-      "dev": true
+      "integrity": "sha512-JZwNWumImYwPNeaf+MV5wEtUvyPK8crjLYo7AVf3/3LQ92oPwi/Clxmg76f14EQm73cbwxKgXTlJbFOSRGQGtA=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -17178,8 +17176,7 @@
     "vanilla-swipe": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/vanilla-swipe/-/vanilla-swipe-2.3.0.tgz",
-      "integrity": "sha512-4m8vZ/kckRG7RQUYNg+0lGILMHT08KEgwePlRLzediDSu7aQFBLB0V2n36vUmYqq5CVWASOzZ8zpnQFZXIbHbA==",
-      "dev": true
+      "integrity": "sha512-4m8vZ/kckRG7RQUYNg+0lGILMHT08KEgwePlRLzediDSu7aQFBLB0V2n36vUmYqq5CVWASOzZ8zpnQFZXIbHbA=="
     },
     "vary": {
       "version": "1.1.2",

--- a/web/carousel/package.json
+++ b/web/carousel/package.json
@@ -19,11 +19,13 @@
     "node-sass": "^5.0.0",
     "qs": "^6.9.4",
     "react": "^17.0.1",
+    "react-alice-carousel": "^2.1.0",
     "react-dom": "^17.0.1",
     "react-geocode": "^0.2.2",
     "react-google-autocomplete": "^1.2.6",
     "react-google-login": "^5.1.25",
     "react-google-maps": "^9.4.5",
+    "react-image-resizer": "^1.3.0",
     "react-multi-carousel": "^2.5.5",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
@@ -60,8 +62,6 @@
   },
   "devDependencies": {
     "@material-ui/core": "^4.11.0",
-    "prettier": "2.1.2",
-    "react-alice-carousel": "^2.1.0",
-    "react-image-resizer": "^1.3.0"
+    "prettier": "2.1.2"
   }
 }


### PR DESCRIPTION
Moved "react-image-resizer" and "react-alice-carousel" library from devDependencies to dependencies.