### PR TITLE
Add implementation of filter for parameters

### DIFF
--- a/backend/dataAccess/product.js
+++ b/backend/dataAccess/product.js
@@ -201,17 +201,15 @@ exports.searchProducts = function (query, tags) {
       $set: {
         maxPrice: { $max: "$vendorSpecifics.price" },
         minPrice: { $min: "$vendorSpecifics.price" },
-        // paramKeys: "$parameters.name",
-
-        // parameters: {
-        //   $arrayToObject: {
-        //     $map: {
-        //       input: "$parameters",
-        //       as: "el",
-        //       in: { k: "$$el.name", v: "$$el.value" },
-        //     },
-        //   },
-        // },
+        parameters: {
+          $arrayToObject: {
+            $map: {
+              input: "$parameters",
+              as: "el",
+              in: { k: "$$el.name", v: "$$el.value" },
+            },
+          },
+        },
         vendors: "$vendorSpecifics.vendorID",
         matches: {
           $reduce: {
@@ -232,37 +230,7 @@ exports.searchProducts = function (query, tags) {
         maxPrice: { $max: "$maxPrice" },
         minPrice: { $min: "$minPrice" },
         vendors: { $push: "$vendors" },
-        // parameters: {
-        //   $accumulator: {
-        //     init: function () {
-        //       result = {};
-        //       for (var key in keys) {
-        //         result[key] = [];
-        //       }
-        //       return { result };
-        //     },
-        //     initArgs: "$paramKeys",
-        //     accumulate: function (state, param) {
-        //       for (var key in param) {
-        //         state.result[key].push(param[key]);
-        //       }
-        //       return { result };
-        //     },
-        //     accumulateArgs: ["$parameters"],
-        //     merge: function (state1, state2) {
-        //       for (key in state1.result) {
-        //         state1.result[key].push(...state2.result[key]);
-        //       }
-        //       return {
-        //         result: state1.result,
-        //       };
-        //     },
-        //     finalize: function (state) {
-        //       return state.result;
-        //     },
-        //     lang: "js",
-        //   },
-        // },
+        parameters: { $push: "$parameters" },
       },
     },
     {
@@ -325,6 +293,7 @@ exports.searchProducts = function (query, tags) {
     { $sort: sort },
     { $skip: skip },
     { $limit: limit },
+    { $unset: ["parameters"] },
   ]);
 };
 

--- a/backend/util/queryHelpers.js
+++ b/backend/util/queryHelpers.js
@@ -42,8 +42,16 @@ exports.filter = function (query) {
         delete obj[key];
         obj["vendors._id"] = { $in: vendorList };
       }
+    } else {
+      if (typeof obj[key] == "string") {
+        let paramList = obj[key].split(",");
+        newkey = `parameters.${key}`;
+        obj[newkey] = { $in: paramList };
+        delete obj[key];
+      }
     }
   }
+  console.log(obj);
   return obj;
 };
 

--- a/backend/util/queryHelpers.js
+++ b/backend/util/queryHelpers.js
@@ -45,6 +45,7 @@ exports.filter = function (query) {
     } else {
       if (typeof obj[key] == "string") {
         let paramList = obj[key].split(",");
+        paramList.forEach((el) => el.toLowerCase());
         newkey = `parameters.${key}`;
         obj[newkey] = { $in: paramList };
         delete obj[key];


### PR DESCRIPTION
Product search was able to filter all but parameters field of products. With this PR filter functionality for parameters is added.

Example: Suppose parameters are `size` and `color`. In the query you can filter like following: `/product/search?size=L,XL&color=red,blue`

The standard filtering options continue to be supported, as in `/product/search?maxPrice[gt]=100&maxPrice[lt]=300&rating=4.5&brand=Apple,Samsung&category=electronics,tablet&vendors=vid1&size=16G,8G&color=green`