### PR TITLE
Backend bug/initialize shopping cart

### DIFF
--- a/backend/models/customer.js
+++ b/backend/models/customer.js
@@ -37,7 +37,7 @@ var creditCard = {
 var customerSchema = new Schema(
   {
     shoppingLists: [shoppingList],
-    shoppingCart: { type: shoppingCart },
+    shoppingCart: [],
     addresses: [address],
     phoneNumber: { type: String },
     birthday: { type: String },


### PR DESCRIPTION
New customers had to add at least one item before being able to access their shoppingCart. Problem's source was shoppingCart was not being initialized properly. This pr fixes the initialization problem.