### PR TITLE
Add endpoint for public vendor profile and improve /product/search

### DIFF
--- a/backend/controllers/product.js
+++ b/backend/controllers/product.js
@@ -3,13 +3,16 @@ const BaseUtil = require("../util/baseUtil");
 const BB = require("bluebird");
 const Product = require("../models/product");
 const factory = require("../services/crudFactory");
+const { isEmpty } = require("underscore");
 
 exports.searchProductsController = BaseUtil.createController((req) => {
-  let tags = req.body.query
-    .trim()
-    .toLowerCase()
-    .split(/[ \t\n]+/);
-  console.log(tags);
+  if (typeof req.body.query == "string") {
+    req.body.query = req.body.query.trim();
+  }
+  if (!isEmpty(req.body.query)) {
+    var tags = req.body.query.toLowerCase().split(/[ \t\n]+/);
+  }
+
   return BB.all([]).then(() =>
     ProductService.searchProductsService({
       query: req.query,

--- a/backend/controllers/vendor.js
+++ b/backend/controllers/vendor.js
@@ -91,6 +91,14 @@ exports.getOneVendorController = BaseUtil.createController((req) => {
   return BB.all([]).then(() => factory.getOne(Vendor)(req));
 });
 
+exports.getOneVendorPublicController = BaseUtil.createController((req) => {
+  return BB.all([]).then(() =>
+    VendorService.getOneVendorPublicService({
+      vid: req.params.id,
+    })
+  );
+});
+
 exports.updateOneVendorController = BaseUtil.createController((req) => {
   return BB.all([]).then(() => factory.updateOne(Vendor)(req));
 });

--- a/backend/documentation/components/responses/_index.yaml
+++ b/backend/documentation/components/responses/_index.yaml
@@ -25,6 +25,9 @@ VendorList:
 Vendor:
   $ref: "./vendor.yaml#/Vendor"
 
+PublicVendor:
+  $ref: "./vendor.yaml#/PublicVendor"
+
 ProductList:
   $ref: "./product.yaml#/ProductList"
 

--- a/backend/documentation/components/responses/vendor.yaml
+++ b/backend/documentation/components/responses/vendor.yaml
@@ -16,3 +16,10 @@ Vendor:
       properties:
         data:
           $ref: "../schemas/_index.yaml#/Vendor"
+PublicVendor:
+  allOf:
+    - $ref: "./general.yaml#/ApiResponse"
+    - type: object
+      properties:
+        data:
+          $ref: "../schemas/_index.yaml#/PublicVendor"

--- a/backend/documentation/components/schemas/_index.yaml
+++ b/backend/documentation/components/schemas/_index.yaml
@@ -13,6 +13,9 @@ Customer:
 Vendor:
   $ref: "./vendor.yaml#/Vendor"
 
+PublicVendor:
+  $ref: "./vendor.yaml#/PublicVendor"
+
 Category:
   $ref: "./category.yaml#/Category"
 

--- a/backend/documentation/components/schemas/customer.yaml
+++ b/backend/documentation/components/schemas/customer.yaml
@@ -35,11 +35,11 @@ Customer:
           vendorId:
             type: String
           amount:
-            type: Number
+            type: number
           price:
-            type: Number
+            type: number
           shipmentPrice:
-            type: Number
+            type: number
           cargoCompany:
             type: String
           vendorName:
@@ -69,7 +69,7 @@ Customer:
             type: String
           phone:
             type: String
-    telephoneNumber:
+    phoneNumber:
       type: string
     birthday:
       type: string

--- a/backend/documentation/components/schemas/order.yaml
+++ b/backend/documentation/components/schemas/order.yaml
@@ -13,47 +13,47 @@ Order:
       type: object
       properties:
         addressName:
-          type: String
+          type: string
         name:
-          type: String
+          type: string
         addressLine:
-          type: String
+          type: string
         city:
-          type: String
+          type: string
         state:
-          type: String
+          type: string
         zipCode:
-          type: String
+          type: string
         phone:
-          type: String
+          type: string
     billingAddress:
       type: object
       properties:
         addressName:
-          type: String
+          type: string
         name:
-          type: String
+          type: string
         addressLine:
-          type: String
+          type: string
         city:
-          type: String
+          type: string
         state:
-          type: String
+          type: string
         zipCode:
-          type: String
+          type: string
         phone:
-          type: String
+          type: string
     creditCard:
       type: object
       properties:
         creditCardNumber:
-          type: String
+          type: string
         creditCardCvc:
-          type: String
+          type: string
         creditCardData:
-          type: String
+          type: string
         creditCardName:
-          type: String
+          type: string
     shippingInfo:
       type: string
     refundProcess:

--- a/backend/documentation/components/schemas/vendor.yaml
+++ b/backend/documentation/components/schemas/vendor.yaml
@@ -26,27 +26,67 @@ Vendor:
       type: object
       properties:
         addressName:
-          type: String
+          type: string
         name:
-          type: String
+          type: string
         addressLine:
-          type: String
+          type: string
         city:
-          type: String
+          type: string
         state:
-          type: String
+          type: string
         zipCode:
-          type: String
+          type: string
         phone:
-          type: String
+          type: string
     locations:
       type: array
       items:
         type: object
         properties:
           longitude:
-            type: Number
+            type: number
           latitude:
-            type: Number
+            type: number
+  xml:
+    name: User
+PublicVendor:
+  type: object
+  properties:
+    _id:
+      type: string
+      format: mongoID
+    companyName:
+      type: string
+    companyDomainName:
+      type: string
+    aboutCompany:
+      type: string
+    address:
+      type: object
+      properties:
+        addressName:
+          type: string
+        name:
+          type: string
+        addressLine:
+          type: string
+        city:
+          type: string
+        state:
+          type: string
+        zipCode:
+          type: string
+        phone:
+          type: string
+    locations:
+      type: array
+      items:
+        type: object
+        properties:
+          longitude:
+            type: number
+          latitude:
+            type: number
   xml:
     name: User

--- a/backend/documentation/paths/_index.yaml
+++ b/backend/documentation/paths/_index.yaml
@@ -67,6 +67,9 @@
 /vendor:
   $ref: "./vendor.yaml#/~1vendor"
 
+"/vendor/public/{id}":
+  $ref: "./vendor.yaml#/~1vendor~1public~1{id}"
+
 "/vendor/{id}":
   $ref: "./vendor.yaml#/~1vendor~1changePassword"
 

--- a/backend/documentation/paths/vendor.yaml
+++ b/backend/documentation/paths/vendor.yaml
@@ -88,6 +88,19 @@
               $ref: "../components/responses/_index.yaml#/ApiResponse"
       "400":
         description: Invalid token
+"/vendor/public/{id}":
+  get:
+    tags:
+      - vendor
+    responses:
+      "200":
+        description: successful operation
+        content:
+          application/json:
+            schema:
+              $ref: "../components/responses/_index.yaml#/PublicVendor"
+      "400":
+        description: Invalid Id
 /vendor/verifyEmail:
   get:
     tags:

--- a/backend/documentation/swagger.yaml
+++ b/backend/documentation/swagger.yaml
@@ -713,6 +713,19 @@ paths:
                 $ref: '#/components/responses/VendorList'
         '400':
           description: Authorization error
+  '/vendor/public/{id}':
+    get:
+      tags:
+        - vendor
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/PublicVendor'
+        '400':
+          description: Invalid Id
   '/vendor/{id}':
     post:
       tags:
@@ -1496,6 +1509,13 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/Vendor'
+    PublicVendor:
+      allOf:
+        - $ref: '#/components/responses/ApiResponse'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/PublicVendor'
     ProductList:
       allOf:
         - $ref: '#/components/responses/ApiResponse'
@@ -1732,11 +1752,11 @@ components:
               vendorId:
                 type: String
               amount:
-                type: Number
+                type: number
               price:
-                type: Number
+                type: number
               shipmentPrice:
-                type: Number
+                type: number
               cargoCompany:
                 type: String
               vendorName:
@@ -1766,7 +1786,7 @@ components:
                 type: String
               phone:
                 type: String
-        telephoneNumber:
+        phoneNumber:
           type: string
         birthday:
           type: string
@@ -1813,28 +1833,68 @@ components:
           type: object
           properties:
             addressName:
-              type: String
+              type: string
             name:
-              type: String
+              type: string
             addressLine:
-              type: String
+              type: string
             city:
-              type: String
+              type: string
             state:
-              type: String
+              type: string
             zipCode:
-              type: String
+              type: string
             phone:
-              type: String
+              type: string
         locations:
           type: array
           items:
             type: object
             properties:
               longitude:
-                type: Number
+                type: number
               latitude:
-                type: Number
+                type: number
+      xml:
+        name: User
+    PublicVendor:
+      type: object
+      properties:
+        _id:
+          type: string
+          format: mongoID
+        companyName:
+          type: string
+        companyDomainName:
+          type: string
+        aboutCompany:
+          type: string
+        address:
+          type: object
+          properties:
+            addressName:
+              type: string
+            name:
+              type: string
+            addressLine:
+              type: string
+            city:
+              type: string
+            state:
+              type: string
+            zipCode:
+              type: string
+            phone:
+              type: string
+        locations:
+          type: array
+          items:
+            type: object
+            properties:
+              longitude:
+                type: number
+              latitude:
+                type: number
       xml:
         name: User
     Category:
@@ -1862,47 +1922,47 @@ components:
           type: object
           properties:
             addressName:
-              type: String
+              type: string
             name:
-              type: String
+              type: string
             addressLine:
-              type: String
+              type: string
             city:
-              type: String
+              type: string
             state:
-              type: String
+              type: string
             zipCode:
-              type: String
+              type: string
             phone:
-              type: String
+              type: string
         billingAddress:
           type: object
           properties:
             addressName:
-              type: String
+              type: string
             name:
-              type: String
+              type: string
             addressLine:
-              type: String
+              type: string
             city:
-              type: String
+              type: string
             state:
-              type: String
+              type: string
             zipCode:
-              type: String
+              type: string
             phone:
-              type: String
+              type: string
         creditCard:
           type: object
           properties:
             creditCardNumber:
-              type: String
+              type: string
             creditCardCvc:
-              type: String
+              type: string
             creditCardData:
-              type: String
+              type: string
             creditCardName:
-              type: String
+              type: string
         shippingInfo:
           type: string
         refundProcess:

--- a/backend/routers/vendor.js
+++ b/backend/routers/vendor.js
@@ -6,9 +6,21 @@ const authController = require("../controllers/authClient");
 const router = express.Router();
 
 router.post("/signup", VendorController.signupController, RequestHelper.returnResponse);
+router.get(
+  "/public/:id",
+  VendorController.getOneVendorPublicController,
+  RequestHelper.returnResponse
+);
+router.use(authController.protectRoute);
 
 // BELOW ARE PROTECTED ROUTES
-router.use(authController.protectRoute);
+router.get("/", VendorController.getAllVendorsController, RequestHelper.returnResponse);
+
+router
+  .route("/:id")
+  .get(VendorController.getOneVendorController, RequestHelper.returnResponse)
+  .patch(VendorController.updateOneVendorController, RequestHelper.returnResponse)
+  .delete(VendorController.deleteOneVendorController, RequestHelper.returnResponse);
 
 router
   .route("/me")
@@ -62,13 +74,5 @@ router
   .get(VendorController.getMyProductRequestController, RequestHelper.returnResponse)
   .patch(VendorController.updateMyProductRequestController, RequestHelper.returnResponse)
   .delete(VendorController.deleteMyProductRequestController, RequestHelper.returnResponse);
-
-router.get("/", VendorController.getAllVendorsController, RequestHelper.returnResponse);
-
-router
-  .route("/:id")
-  .get(VendorController.getOneVendorController, RequestHelper.returnResponse)
-  .patch(VendorController.updateOneVendorController, RequestHelper.returnResponse)
-  .delete(VendorController.deleteOneVendorController, RequestHelper.returnResponse);
 
 module.exports = router;

--- a/backend/services/vendor.js
+++ b/backend/services/vendor.js
@@ -10,6 +10,7 @@ const AppError = require("../util/appError");
 const Formatters = require("../util/format");
 const sendEmail = require("../util/emailer");
 const Config = require("../config");
+
 //
 exports.signupService = async function ({
   email,
@@ -175,4 +176,9 @@ exports.createMyNewProductService = async function ({ vid, data }) {
   return {
     data: newProductRequest,
   };
+};
+
+exports.getOneVendorPublicService = async function ({ vid }) {
+  newProductRequest = await VendorDataAccess.getVendorByIdDB(vid);
+  return Formatters.formatVendorPublic(newProductRequest);
 };

--- a/backend/util/format.js
+++ b/backend/util/format.js
@@ -63,9 +63,32 @@ exports.formatVendor = function ({
       aboutCompany,
       address,
       locations,
+      phoneNumber,
       IBAN,
       isActive,
       isSuspended,
+    },
+  };
+};
+
+exports.formatVendorPublic = function ({
+  _id,
+  companyName,
+  companyDomainName,
+  aboutCompany,
+  address,
+  locations,
+  phoneNumber,
+}) {
+  return {
+    data: {
+      _id: _id.toString(),
+      companyName,
+      companyDomainName,
+      aboutCompany,
+      address,
+      locations,
+      phoneNumber,
     },
   };
 };


### PR DESCRIPTION
With these changes customers are able to get vendor's public profile and see their products. Changes are:
- I added a new endpoint `GET /vendor/public/{id}` which returns the public profile of a vendor.
- For vendor's all products I modified the endpoint `POST /product/search` so that customers don't have to enter a query string to be able to use filtering and sorting features.

I also added the documentation for `GET /vendor/public/{id}` and improved some parts in the documentation that had erroneous "String" which OpenAPI doesn't recognize.