### PR TITLE
Fix /vendor/me endpoint

### DIFF
--- a/backend/routers/vendor.js
+++ b/backend/routers/vendor.js
@@ -17,16 +17,16 @@ router.use(authController.protectRoute);
 router.get("/", VendorController.getAllVendorsController, RequestHelper.returnResponse);
 
 router
-  .route("/:id")
-  .get(VendorController.getOneVendorController, RequestHelper.returnResponse)
-  .patch(VendorController.updateOneVendorController, RequestHelper.returnResponse)
-  .delete(VendorController.deleteOneVendorController, RequestHelper.returnResponse);
-
-router
   .route("/me")
   .get(VendorController.getProfile, RequestHelper.returnResponse)
   .patch(VendorController.patchProfile, RequestHelper.returnResponse)
   .delete(VendorController.freezeProfile, RequestHelper.returnResponse);
+
+router
+  .route("/:id")
+  .get(VendorController.getOneVendorController, RequestHelper.returnResponse)
+  .patch(VendorController.updateOneVendorController, RequestHelper.returnResponse)
+  .delete(VendorController.deleteOneVendorController, RequestHelper.returnResponse);
 
 router.get(
   "/me/product",

--- a/backend/util/format.js
+++ b/backend/util/format.js
@@ -50,6 +50,7 @@ exports.formatVendor = function ({
   aboutCompany,
   address,
   locations,
+  phoneNumber,
   IBAN,
   isActive,
   isSuspended,


### PR DESCRIPTION
In the router file for vendor paths `/vendor/me` and `/vendor/:id` clash. If `/vendor/:id` is put before the  `/vendor/me` the queries never reach to `/vendor/me`. This PR fixes the problem.

There was also a missing field in the vendor formatter function. I fixed that too.