### PR TITLE
fixed type mismatched bug  causing vendor history to be unreachable.

### DIFF
--- a/backend/dataAccess/order.js
+++ b/backend/dataAccess/order.js
@@ -19,14 +19,14 @@ exports.getOrderByCustomerIdDB = function (customerID) {
 
 exports.getOrderByVendorIdDB = function (vendorID) {
   return Order.aggregate([
-    { $match: { "orders.vendorId": vendorID } },
+    { $match: { "orders.vendorId": mongoose.Types.ObjectId(vendorID) } },
     {
       $project: {
         orders: {
           $filter: {
             input: "$orders",
             as: "order",
-            cond: { $eq: ["$$order.vendorId", vendorID] },
+            cond: { $eq: ["$$order.vendorId", mongoose.Types.ObjectId(vendorID)] },
           },
         },
         _id: 1,


### PR DESCRIPTION
Relating bug: https://github.com/bounswe/bounswe2020group8/issues/450

Found reason:
[Order model update](https://github.com/bounswe/bounswe2020group8/pull/445) caused type mismatches with vendor order history endpoint.

Solution:
Mismatched type casted into correct type in vendor order history database search.