### PR TITLE
Added vendor order pages and order status change

### DIFF
--- a/web/carousel/src/components/Account/VendorOrders/InactiveOrders.js
+++ b/web/carousel/src/components/Account/VendorOrders/InactiveOrders.js
@@ -1,0 +1,180 @@
+import React, {Component} from "react";
+import Table from "antd/lib/table";
+
+import services from "../../../apis/services";
+import {Space} from "antd";
+import classes from "./Orders.module.css";
+
+export class InactiveOrders extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      orders: [],
+      loading: true,  // loading state for the table
+    };
+  }
+
+  // get orders on mount
+  componentDidMount() {
+    this.setState({loading: true});
+    this.getMyOrders();
+  }
+
+  // get all orders
+  getMyOrders = () => {
+    this.setState({orders: []});
+    const TOKEN = localStorage.getItem("token");
+    const config = {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    };
+    services.get("/vendor/order/main", config)
+      .then(response => {
+        this.sortOrders(response.data.data);
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  }
+
+  // orders for each product are extracted
+  sortOrders = (data) => {
+    let list = [];
+    for (let i = 0; i < data.length; i++) {
+      const customer = data[i].customerID;
+      const mainOrderID = data[i]._id;
+      for (let k = 0; k < data[i].orders.length; k++) {
+        const order = data[i].orders[k];
+        const orderID = order._id;
+        this.getOrderProduct(order.productId, order, i + "0000" + k, customer, mainOrderID, orderID);
+      }
+    }
+  }
+
+  // get order specific product info
+  getOrderProduct = (productID, order, key, customer, mainOrderID, orderID) => {
+    let list = [];
+    const TOKEN = localStorage.getItem("token");
+    const config = {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    };
+    let data;
+    let title;
+    let parameters = [];
+    services.get("/vendor/me/product/" + productID, config)
+      .then(response => {
+        data = response.data.data[0];
+
+        // get parameter values
+        for (let i = 0; i < data.parameters.length; i++){
+          if (i !== data.parameters.length - 1) parameters.push(data.parameters[i].value + ", ");
+          else parameters.push(data.parameters[i].value);
+        }
+
+        services.get("/mainProduct/" + data.parentProduct, config)
+          .then(res => {
+            title = res.data.data.title;
+            this.setState({loading: false});
+            let product;
+            product = {
+              title: title,
+              brand: data.brand,
+              parameters: parameters,
+            };
+
+            const orderProduct = {
+              key: key,
+              amount: order.amount,
+              status: order.status,
+              price: order.price,
+              cargoCompany: order.cargoCompany,
+              shipmentPrice: order.shipmentPrice,
+              address: order.shippingAddress,
+              payment: order.creditCard,
+              customer: customer,
+              product: order.productId,
+              title: title,
+              brand: data.brand,
+              parameters: parameters,
+              mainOrderID: mainOrderID,
+              orderID: orderID,
+            }
+
+            // list only inactive orders
+            if(orderProduct.status === "returned" || orderProduct.status === "cancelled by the customer" || orderProduct.status === "delivered")
+              this.setState({
+                orders: [...this.state.orders, orderProduct],
+              });
+          })
+          .catch(err => {
+            console.log(err);
+          })
+
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  }
+
+  render(){
+    const columns = [
+      {
+        title: "Product Name",
+        dataIndex: "title",
+        key: "title",
+      },
+      {
+        title: "Customer ID",
+        dataIndex: "customer",
+        key: "customer",
+        defaultSortOrder: 'descend',
+        sorter: (a, b) => a.customer - b.customer,
+      },
+      {
+        title: "Parameters",
+        dataIndex: "parameters",
+        key: "parameters",
+      },
+      {
+        title: "Price",
+        dataIndex: "price",
+        key: "price",
+      },
+      {
+        title: "Amount",
+        dataIndex: "amount",
+        key: "amount",
+      },
+      {
+        title: "Cargo Company",
+        dataIndex: "cargoCompany",
+        key: "cargoCompany",
+      },
+      {
+        title: "Shipment Price",
+        dataIndex: "shipmentPrice",
+        key: "shipmentPrice",
+      },
+      {
+        title: "Status",
+        dataIndex: "status",
+        key: "status",
+        onFilter: (value, record) => record.status.indexOf(value) === 0,
+        sorter: (a, b) => a.status.length - b.status.length,
+        sortDirections: ['descend', 'ascend'],
+      },
+    ];
+
+    const data = this.state.orders;
+    return (
+      <div>
+        <Table
+          dataSource={data}
+          loading={this.state.loading}
+          columns={columns}
+        />
+      </div>
+    );
+  }
+}
+
+export default InactiveOrders;

--- a/web/carousel/src/components/Account/VendorOrders/Orders.js
+++ b/web/carousel/src/components/Account/VendorOrders/Orders.js
@@ -1,0 +1,243 @@
+import React, {Component} from "react";
+import Table from "antd/lib/table";
+
+import services from "../../../apis/services";
+import {Space} from "antd";
+import classes from "./Orders.module.css";
+import confirmPopup from "../../UI/ConfirmPopup/ConfirmPopup";
+
+export class Orders extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      orders: [],
+      loading: true,
+    };
+  }
+
+  // get orders on mount
+  componentDidMount() {
+    this.setState({loading: true});
+    this.getMyOrders();
+  }
+
+  // get all orders
+  getMyOrders = () => {
+    this.setState({orders: []});
+    const TOKEN = localStorage.getItem("token");
+    const config = {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    };
+    services.get("/vendor/order/main", config)
+      .then(response => {
+        this.sortOrders(response.data.data);
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  }
+
+  // orders for each product are extracted
+  sortOrders = (data) => {
+    let list = [];
+    for (let i = 0; i < data.length; i++) {
+      const customer = data[i].customerID;
+      const mainOrderID = data[i]._id;
+      for (let k = 0; k < data[i].orders.length; k++) {
+        const order = data[i].orders[k];
+        const orderID = order._id;
+        this.getOrderProduct(order.productId, order, i + "0000" + k, customer, mainOrderID, orderID);
+      }
+    }
+  }
+
+  // get order specific product info
+  getOrderProduct = (productID, order, key, customer, mainOrderID, orderID) => {
+    let list = [];
+    const TOKEN = localStorage.getItem("token");
+    const config = {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    };
+    let data;
+    let title;
+    let parameters = [];
+    services.get("/vendor/me/product/" + productID, config)
+      .then(response => {
+        data = response.data.data[0];
+        // get parameter values
+        for (let i = 0; i < data.parameters.length; i++){
+          if (i !== data.parameters.length - 1) parameters.push(data.parameters[i].value + ", ");
+          else parameters.push(data.parameters[i].value);
+        }
+
+        services.get("/mainProduct/" + data.parentProduct, config)
+          .then(res => {
+            title = res.data.data.title;
+            let product;
+            product = {
+              title: title,
+              brand: data.brand,
+              parameters: parameters,
+            };
+
+            this.setState({loading: false});
+            const orderProduct = {
+              key: key,
+              amount: order.amount,
+              status: order.status,
+              price: order.price,
+              cargoCompany: order.cargoCompany,
+              shipmentPrice: order.shipmentPrice,
+              address: order.shippingAddress,
+              payment: order.creditCard,
+              customer: customer,
+              product: order.productId,
+              title: title,
+              brand: data.brand,
+              parameters: parameters,
+              mainOrderID: mainOrderID,
+              orderID: orderID,
+            }
+
+            console.log(orderProduct);
+
+            // list only active products
+            if(orderProduct.status !== "returned" && orderProduct.status !== "cancelled by the customer" && orderProduct.status !== "delivered")
+            this.setState({
+              orders: [...this.state.orders, orderProduct],
+            });
+          })
+          .catch(err => {
+            console.log(err);
+          })
+
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  }
+
+  changeStatusHandler = (order, statusNumber) => {
+    let status;
+    if (statusNumber === 1) status = "being prepared";
+    else if (statusNumber === 2) status = "on the way";
+    else if (statusNumber === 3) status = "delivered";
+    const TOKEN = localStorage.getItem("token");
+    const config = {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    };
+    const payload = {
+      mainOrderID: order.mainOrderID,
+      orderID: order.orderID,
+      status: status,
+    }
+    services.patch("/vendor/order/main", payload, config)
+      .then(response => {
+        if (statusNumber === 1) alert("Order is being prepared!");
+        else if (statusNumber === 2) alert("Order is now on the way to the customer!");
+        else if (statusNumber === 3) alert("Order is DELIVERED!");
+
+        this.getMyOrders();
+      })
+      .catch(error => {
+        console.log(error);
+      })
+  }
+
+  render(){
+    const columns = [
+      {
+        title: "Product Name",
+        dataIndex: "title",
+        key: "title",
+      },
+      {
+        title: "Customer ID",
+        dataIndex: "customer",
+        key: "customer",
+        defaultSortOrder: 'descend',
+        sorter: (a, b) => a.customer - b.customer,
+      },
+      {
+        title: "Parameters",
+        dataIndex: "parameters",
+        key: "parameters",
+      },
+      {
+        title: "Price",
+        dataIndex: "price",
+        key: "price",
+      },
+      {
+        title: "Amount",
+        dataIndex: "amount",
+        key: "amount",
+      },
+      {
+        title: "Cargo Company",
+        dataIndex: "cargoCompany",
+        key: "cargoCompany",
+      },
+      {
+        title: "Shipment Price",
+        dataIndex: "shipmentPrice",
+        key: "shipmentPrice",
+      },
+      {
+        title: "Status",
+        key: "action",
+        render: (id, record) => (
+          <Space size="large">
+            <a
+              className={id.status === "being prepared" ? classes.TableActionsCurrent : classes.TableActionsSuspend}
+              onClick={() => {
+                id.status === "being prepared" ?
+                  alert("Order is already being prepared!")
+                :
+                  this.changeStatusHandler(record, 1);
+              }}
+            >
+              being prepared
+            </a>
+            <a
+              className={id.status === "on the way" ? classes.TableActionsCurrent : classes.TableActionsSuspend}
+              onClick={() => {
+                id.status === "on the way" ?
+                  alert("Order is already on the way!")
+                  :
+                  this.changeStatusHandler(record, 2);
+              }}
+            >
+              on the way
+            </a>
+            <a
+              className={classes.TableActionsSuspend}
+              onClick={() => {
+                id.status === "delivered" ?
+                  alert("Order is already delivered!")
+                  :
+                  this.changeStatusHandler(record, 3);
+              }}
+            >
+              DELIVER
+            </a>
+            <br />
+          </Space>
+        ),
+      },
+    ];
+
+    const data = this.state.orders;
+    return (
+      <div>
+        <Table
+          dataSource={data}
+          columns={columns}
+          loading={this.state.loading}
+        />
+      </div>
+    );
+  }
+}
+
+export default Orders;

--- a/web/carousel/src/components/Account/VendorOrders/Orders.module.css
+++ b/web/carousel/src/components/Account/VendorOrders/Orders.module.css
@@ -1,0 +1,15 @@
+.TableActionsSuspend{
+  color: #FF9100;
+}
+
+.TableActionsSuspend:hover {
+  color: #FF6D00;
+}
+
+.TableActionsCurrent {
+  color: #ff3100;
+}
+
+.Deliver {
+  color: green;
+}

--- a/web/carousel/src/screens/VendorAccount/ActiveOrder.js
+++ b/web/carousel/src/screens/VendorAccount/ActiveOrder.js
@@ -1,7 +1,10 @@
-import React, { Component } from "react";
+import React, from "react";
+import Orders from "../../components/Account/VendorOrders/Orders";
 
-export default class ActiveOrder extends Component {
-  render() {
-    return <div>ActiveOrder</div>;
-  }
+export default function ActiveOrder() {
+  return (
+    <div>
+      <Orders />
+    </div>
+    );
 }

--- a/web/carousel/src/screens/VendorAccount/ActiveOrder.js
+++ b/web/carousel/src/screens/VendorAccount/ActiveOrder.js
@@ -1,4 +1,4 @@
-import React, from "react";
+import React from "react";
 import Orders from "../../components/Account/VendorOrders/Orders";
 
 export default function ActiveOrder() {

--- a/web/carousel/src/screens/VendorAccount/InactiveOrder.js
+++ b/web/carousel/src/screens/VendorAccount/InactiveOrder.js
@@ -1,7 +1,10 @@
-import React, { Component } from "react";
+import React from "react";
+import InactiveOrders from "../../components/Account/VendorOrders/InactiveOrders";
 
-export default class InactiveOrder extends Component {
-  render() {
-    return <div>InactiveOrder</div>;
-  }
+export default function InactiveOrder() {
+  return (
+    <div>
+      <InactiveOrders />
+    </div>
+  );
 }

--- a/web/carousel/src/screens/VendorAccount/index.js
+++ b/web/carousel/src/screens/VendorAccount/index.js
@@ -67,7 +67,7 @@ class VendorAccount extends Component {
           </SubMenu>
           <SubMenu key="/order" icon={<ShoppingOutlined />} title="My Order">
             <Menu.Item key="active-order">
-              <Link to="/vendor/account/active">Active Orders</Link>
+              <Link to="/vendor/account/active-order">Active Orders</Link>
             </Menu.Item>
             <Menu.Item key="inactive-order">
               <Link to="/vendor/account/inactive-order">Inactive Orders</Link>


### PR DESCRIPTION
Vendors now can see their active and inactive orders. See issue #442 .

- They can change status of the active orders as: "being prepared", "on the way" and "delivered".
- They can see their active and inactive orders in different pages and sort them accordingly.
- In active orders page, the active status is shown with the darker color.


<img width="1440" alt="Screen Shot 2021-01-23 at 22 03 04" src="https://user-images.githubusercontent.com/31131763/105611506-e01f7d80-5dc6-11eb-82c5-7374a88fc313.png">

<img width="1440" alt="Screen Shot 2021-01-23 at 22 05 45" src="https://user-images.githubusercontent.com/31131763/105611577-2ecd1780-5dc7-11eb-9f39-31ab09fb6a99.png">
