### PR TITLE
Added order track interface for guests

### DIFF
--- a/web/carousel/src/components/Header/Categories/Categories.module.css
+++ b/web/carousel/src/components/Header/Categories/Categories.module.css
@@ -1,5 +1,5 @@
 .Categories {
-    height: 70px;
+    height: 40px;
     background-color: rgb(236, 236, 236);
     width: 100%;
     display: inline-flex;

--- a/web/carousel/src/components/Header/Header.js
+++ b/web/carousel/src/components/Header/Header.js
@@ -3,6 +3,7 @@ import { withRouter } from "react-router-dom";
 import Categories from "./Categories/Categories";
 import SearchBar from "./SearchBar/SearchBar";
 import SideButtons from "./SideButtons/SideButtons";
+import OrderTrack from "./OrderTrack/OrderTrack";
 import classes from "./Header.module.css";
 import logo from "../../assets/images/carousel_logo.jpg";
 import qs from "qs";
@@ -60,6 +61,17 @@ export class Header extends Component {
     return (
       <>
         <header className={classes.Header}>
+          <div
+            className={classes.Toolbar}
+            style={{ height: "20px", borderBottom: "none" }}
+          >
+            <a
+              className={classes.Track}
+              onClick={() => this.props.history.push("/order-track")}
+            >
+              Track your order
+            </a>
+          </div>
           <div className={classes.Toolbar}>
             <img
               src={logo}

--- a/web/carousel/src/components/Header/Header.module.css
+++ b/web/carousel/src/components/Header/Header.module.css
@@ -49,3 +49,13 @@
   height: 150px;
   width: 100%;
 }
+
+.Track {
+  color: #FF6D00;
+  float: right;
+  right: 0;
+  margin-left: 1250px;
+}
+.Track:hover {
+  color: #d33a09;
+}

--- a/web/carousel/src/components/Header/OrderTrack/OrderTrack.js
+++ b/web/carousel/src/components/Header/OrderTrack/OrderTrack.js
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import services from "../../../apis/services";
+import { Button, Form, Input, message, Steps } from "antd";
+import classes from "../../Account/VendorAddProduct/AddProduct.module.css";
+import OrderDetail from "../../../screens/Account/OrderDetail";
+import ProductBox from "../../Product/ProductBox";
+
+const { Step } = Steps;
+
+const layout = {
+  labelCol: { span: 14 },
+  wrapperCol: { span: 28 },
+};
+const validateMessages = {
+  required: "${label} is required!",
+  types: {
+    email: "${label} is not a valid email!",
+    number: "${label} is not a valid number!",
+  },
+  number: {
+    range: "${label} must be between ${min} and ${max}",
+  },
+};
+const OrderTrack = (props) => {
+  const [showOrder, setShowOrder] = useState(false);
+  const [order, setOrder] = useState({});
+
+  const getOrder = (values) => {
+    const trackNo = values.user.trackNo;
+    const URL = "/guest/order/mainOrderId";
+    const payload = {
+      mainOrderID: trackNo,
+    };
+    services
+      .post(URL, payload)
+      .then((response) => {
+        console.log(response);
+        setOrder(response.data.data);
+        setShowOrder(true);
+      })
+      .catch((error) => {
+        console.log(error);
+        message.warning("No order found for the given order track number!");
+      });
+  };
+
+  let component;
+  if (!showOrder) {
+    component = (
+      <div>
+        <p style={{ fontSize: "14px", fontWeight: "bold" }}>
+          Enter your order tracking number below
+        </p>
+        <Form
+          {...layout}
+          className={classes.myReset}
+          name="dynamic_form_nest_item"
+          onFinish={getOrder}
+          validateMessages={validateMessages}
+        >
+          <Form.Item
+            name={["user", "trackNo"]}
+            label="Order tracking number"
+            rules={[{ required: true }]}
+          >
+            <Input placeholder="order track no" style={{ width: "300px" }} />
+          </Form.Item>
+          <Form.Item wrapperCol={{ ...layout.wrapperCol, offset: 8 }}>
+            <Button type="primary" htmlType="submit">
+              Submit
+            </Button>
+          </Form.Item>
+        </Form>
+      </div>
+    );
+  } else {
+    component = (
+      <div>
+        <OrderDetail guest={true} guestOrder={order} />
+      </div>
+    );
+  }
+  return <div>{component}</div>;
+};
+export default OrderTrack;

--- a/web/carousel/src/components/Product/ProductBox.js
+++ b/web/carousel/src/components/Product/ProductBox.js
@@ -106,11 +106,11 @@ const ProductBox = (props) => {
           ) : null}
           {props.orderDetail ? (
             <>
-              <div style={{ fontSize: 16 }}>Amount: {props.product.amount}</div>
-              <div>
+              <div style={{ fontSize: 13 }}>
+                <div>Amount: {props.product.amount}</div>
                 <div>${props.product.price * props.product.amount}</div>
               </div>
-              <div>
+              <div style={{ fontSize: 13 }}>
                 <div>Arrive after {props.product.arrivesIn} days</div>
               </div>
               {[

--- a/web/carousel/src/screens/OrderTrack/index.js
+++ b/web/carousel/src/screens/OrderTrack/index.js
@@ -1,0 +1,12 @@
+import React from "react";
+import OrderTrack from "../../components/Header/OrderTrack/OrderTrack";
+
+export default function OrderTrackPage() {
+  return (
+    <div className="App">
+      <header className="App-content">
+        <OrderTrack />
+      </header>
+    </div>
+  );
+}

--- a/web/carousel/src/screens/index.js
+++ b/web/carousel/src/screens/index.js
@@ -20,6 +20,7 @@ import Search from "./Search";
 import VendorAccount from "./VendorAccount";
 import VendorHome from "./VendorHome";
 import VendorPublicPage from "./VendorHome/VendorPublicPage";
+import OrderTrackPage from "./OrderTrack";
 
 function PrivateRoute({ component: Component, authed, ...rest }) {
   return (
@@ -103,6 +104,7 @@ const App = () => {
     { path: "/reset", exact: true, component: Reset },
     { path: "/forgot", exact: true, component: Forgot },
     { path: "/search", exact: true, component: Search },
+    { path: "/order-track", exact: true, component: OrderTrackPage },
     { path: "/product/:id", exact: true, component: Product },
     { path: "/v/public/:id", exact: true, component: VendorPublicPage },
     {


### PR DESCRIPTION
The guests can track their orders from the website from now on. They will enter their tracking number they received after a purchase or to their emails. They can see their orders' status and cancel if necessary.

<img width="1440" alt="Screen Shot 2021-01-25 at 16 31 25" src="https://user-images.githubusercontent.com/31131763/105712549-ff372000-5f2a-11eb-871a-52a0b775e890.png">

<img width="1435" alt="Screen Shot 2021-01-25 at 16 35 24" src="https://user-images.githubusercontent.com/31131763/105712857-7967a480-5f2b-11eb-99ca-0835f8bbbba2.png">

<img width="1436" alt="Screen Shot 2021-01-25 at 16 35 30" src="https://user-images.githubusercontent.com/31131763/105712868-7d93c200-5f2b-11eb-92d2-a825e62c295b.png">

