### PR TITLE
Improve product search and recommendation by integrating DataMuse API

### DIFF
--- a/backend/services/customer.js
+++ b/backend/services/customer.js
@@ -10,6 +10,8 @@ const AppError = require("../util/appError");
 const Formatters = require("../util/format");
 const sendEmail = require("../util/emailer");
 const Config = require("../config");
+const Constants = require("../util/constants");
+
 //
 
 exports.signupService = async function ({ email, password, name, lastName }) {
@@ -128,6 +130,11 @@ exports.getProductRecommendationService = async function ({ customer }) {
 
   allTags = orderTags.concat(searchTags);
   freqTable = listToFreqDict(allTags);
+  console.log(freqTable);
+  Constants.BASIC_COLORS.forEach((el) => {
+    delete freqTable[el];
+  });
+  console.log(freqTable);
 
   delete freqTable.hotsellers;
   delete freqTable.trendings;

--- a/backend/services/product.js
+++ b/backend/services/product.js
@@ -8,8 +8,41 @@ const { isNullOrEmpty } = require("../util/coreUtil");
 const AppError = require("../util/appError");
 const Messages = require("../util/messages");
 const NotificationWare = require("../util/notification");
+const Constants = require("../util/constants");
+const got = require("got");
 
+/*
+Searchs for products related to tags, it queries the semantic search API of datamuse to gather
+other related words with the tags. Then it queries the database for related products.
+*/
 exports.searchProductsService = async function ({ query, tags }) {
+  if (!isNullOrEmpty(tags)) {
+    tags = tags.filter((el) => {
+      return Constants.BASIC_COLORS.indexOf(el) == -1;
+    });
+
+    tags_string = tags.join("+");
+    let response_body = (
+      await got(`https://api.datamuse.com/words?ml=${tags_string}`, {
+        json: true,
+      })
+    ).body;
+    new_tags = response_body
+      .filter((el) => {
+        if (el.tags) {
+          return el.tags.indexOf("v") == -1;
+        } else {
+          return true;
+        }
+      })
+      .splice(0, 10)
+      .map((el) => {
+        return el.word;
+      });
+    tags = tags.concat(new_tags);
+    console.log(tags);
+  }
+
   let products = await ProductDataAccess.searchProducts(query, tags);
   if (isNullOrEmpty(products)) {
     throw new AppError(Messages.RETURN_MESSAGES.ERR_SOMETHING_WENT_WRONG);
@@ -23,6 +56,11 @@ exports.getProductRecommendationService = async function ({ pid }) {
     throw new AppError(Messages.RETURN_MESSAGES.ERR_SOMETHING_WENT_WRONG);
   }
   let { tags, parentProduct } = product;
+  if (!isNullOrEmpty(tags)) {
+    tags = tags.filter((el) => {
+      return Constants.BASIC_COLORS.indexOf(el) == -1;
+    });
+  }
   recIndex = tags.indexOf("hotsellers");
   if (recIndex != 1) {
     tags.splice(recIndex, 1);

--- a/backend/services/product.js
+++ b/backend/services/product.js
@@ -15,32 +15,35 @@ const got = require("got");
 Searchs for products related to tags, it queries the semantic search API of datamuse to gather
 other related words with the tags. Then it queries the database for related products.
 */
+async function getRelatedTags(tags) {
+  tags_string = tags.join("+");
+  let response_body = (
+    await got(`https://api.datamuse.com/words?ml=${tags_string}`, {
+      json: true,
+    })
+  ).body;
+  new_tags = response_body
+    .filter((el) => {
+      if (el.tags) {
+        return el.tags.indexOf("v") == -1;
+      } else {
+        return true;
+      }
+    })
+    .splice(0, 10)
+    .map((el) => {
+      return el.word;
+    });
+  return new_tags;
+}
+
 exports.searchProductsService = async function ({ query, tags }) {
   if (!isNullOrEmpty(tags)) {
     tags = tags.filter((el) => {
       return Constants.BASIC_COLORS.indexOf(el) == -1;
     });
-
-    tags_string = tags.join("+");
-    let response_body = (
-      await got(`https://api.datamuse.com/words?ml=${tags_string}`, {
-        json: true,
-      })
-    ).body;
-    new_tags = response_body
-      .filter((el) => {
-        if (el.tags) {
-          return el.tags.indexOf("v") == -1;
-        } else {
-          return true;
-        }
-      })
-      .splice(0, 10)
-      .map((el) => {
-        return el.word;
-      });
+    new_tags = await getRelatedTags(tags);
     tags = tags.concat(new_tags);
-    console.log(tags);
   }
 
   let products = await ProductDataAccess.searchProducts(query, tags);
@@ -61,6 +64,9 @@ exports.getProductRecommendationService = async function ({ pid }) {
       return Constants.BASIC_COLORS.indexOf(el) == -1;
     });
   }
+  new_tags = await getRelatedTags(tags);
+  tags = tags.concat(new_tags);
+
   recIndex = tags.indexOf("hotsellers");
   if (recIndex != 1) {
     tags.splice(recIndex, 1);

--- a/backend/util/constants.js
+++ b/backend/util/constants.js
@@ -282,6 +282,7 @@ const constants = {
     ORDER_MESSAGE_REPLIED_BY_VENDOR: "One of your order messages has been replied by a vendor.",
     ORDER_MESSAGE_REPLIED_BY_CUSTOMER: "One of your order messages has been replied by a customer.",
   },
+  BASIC_COLORS: ["black", "blue", "red", "green", "orange", "violet", "white", "brown"],
 };
 
 module.exports = constants;


### PR DESCRIPTION
DataMuse API returns semantically related words about the queries the customers send when they search for products. With the use of this API, we return more related products.

I also removed the effects of color information when searching and recommending products. Color information used to cause unrelated products to be shown in both recommendations and search. With this PR, color information is only used when filtering the searched products.