### PR TITLE
Add category filtering feature for searchFilters endpoint

### DIFF
--- a/backend/controllers/product.js
+++ b/backend/controllers/product.js
@@ -31,10 +31,12 @@ exports.getProductRecommendationController = BaseUtil.createController((req) => 
 });
 
 exports.getSearchFiltersController = BaseUtil.createController((req) => {
-  let tags = req.body.query
-    .trim()
-    .toLowerCase()
-    .split(/[ \t\n]+/);
+  if (typeof req.body.query == "string") {
+    req.body.query = req.body.query.trim();
+  }
+  if (!isEmpty(req.body.query)) {
+    var tags = req.body.query.toLowerCase().split(/[ \t\n]+/);
+  }
   return BB.all([]).then(() =>
     ProductService.getSearchFiltersService({
       query: req.query,

--- a/backend/dataAccess/product.js
+++ b/backend/dataAccess/product.js
@@ -405,8 +405,16 @@ exports.searchProducts = function (query, tags) {
 };
 
 exports.getSearchFilters = function (query, tags) {
+  let filter = QueryHelper.filter(query);
+  let matched_statement;
+  if (!isNullOrEmpty(tags)) {
+    matched_statement = { $match: { tags: { $in: tags } } };
+  } else {
+    matched_statement = { $match: filter };
+    tags = [];
+  }
   return Product.aggregate([
-    { $match: { tags: { $in: tags } } },
+    matched_statement,
     {
       $set: {
         maxPrice: { $max: "$vendorSpecifics.price" },


### PR DESCRIPTION
The category pages for products use both `POST /product/search` and `POST /product/searchFilters` endpoints. Search endpoint works without a problem with category filtering. However, searchFilters used to not return any results when users tried to get filters only for a certain category of products. This PR solves the problem.