### PR TITLE
Fixed product title overlapping other information

### DIFF
--- a/web/carousel/src/components/Product/Product.module.css
+++ b/web/carousel/src/components/Product/Product.module.css
@@ -37,7 +37,7 @@
 }
 
 .ProductHeader_name {
-  font-size: 28px;
+  font-size: 18px;
   height: 40px;
   color: black;
 }

--- a/web/carousel/src/components/Product/ProductHeader/ProductHeader.js
+++ b/web/carousel/src/components/Product/ProductHeader/ProductHeader.js
@@ -18,7 +18,7 @@ const ProductHeader = ({
       <div style={{ height: "120px", textAlign: "left", marginLeft: "10px" }}>
         <div className={classes.ProductHeader_name}>{name}</div>
         <p
-          style={{ marginLeft: "8px", fontSize: "12px" }}
+          style={{ marginLeft: "8px", fontSize: "12px", marginTop:"20px" }}
           className={classes.ProductHeader_name}
         >
           Brand: {brand}
@@ -57,7 +57,7 @@ const ProductHeader = ({
           </p>
         </div>
       </div>
-      <div style={{ height: "80px" }}>
+      <div style={{ height: "80px", marginTop:"16px" }}>
         <p className={classes.ProductHeader_price}>$ {price}</p>
       </div>
       <div


### PR DESCRIPTION
See issue #579 .

With this PR, the product page information will be more readable!

<img width="1440" alt="Screen Shot 2021-01-31 at 15 39 26" src="https://user-images.githubusercontent.com/31131763/106384116-8debe700-63da-11eb-866d-15b7b51fa67f.png">
